### PR TITLE
Update unity-hub to version 2.4.3

### DIFF
--- a/unity-hub/tools/chocolateyinstall.ps1
+++ b/unity-hub/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@
 
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $url64 = "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup.exe"
-$checksum64 = "7d5222d9094b4ea58d9591561aa2252ee278c9131753979cd99dd507aa27de48"
+$checksum64 = "3cb22764ae2c467486448088d3c045e7d5d209b4adfeccc3e7de84beadb2ef36"
 
 $args = "/S"
 

--- a/unity-hub/unity-hub.nuspec
+++ b/unity-hub/unity-hub.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>unity-hub</id>
-    <version>2.4.2</version>
+    <version>2.4.3</version>
     <packageSourceUrl>https://github.com/JipSterk/Chocolatey-Packages/tree/master/unity-hub</packageSourceUrl>
     <owners>JipSterk</owners>
     <title>Unity Hub (install)</title>


### PR DESCRIPTION
Your automatic updater action doesn't seem to be working. I have no idea why (I've never used GitHub Actions for anything before) so here's a manual update. 😄